### PR TITLE
Upgrade set-v2-strategies to 0.0.4, set-protocol-v2 to 0.1.12

### DIFF
--- a/optimism/deploy/001_perpLeverageSystem.ts
+++ b/optimism/deploy/001_perpLeverageSystem.ts
@@ -2,6 +2,8 @@ import "module-alias/register";
 
 import { HardhatRuntimeEnvironment as HRE } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
+import { ZERO } from "@utils/constants";
+import { BigNumber } from "ethers";
 
 import {
   findDependency,
@@ -33,6 +35,8 @@ import {
   EXECUTION_SETTINGS,
   INCENTIVE_SETTINGS,
   METHODOLOGY_SETTINGS,
+  ETH_DECIMALS,
+  ETH_USDC_PRICE_FEED_DECIMALS,
 } from "./../deployments/constants/001_perpLeverageSystem";
 
 const {
@@ -42,9 +46,9 @@ const {
   V_ETH,
   V_USD,
   ETH_CHAINLINK_ORACLE,
-  USDC_CHAINLINK_ORACLE,
 } = DEPENDENCY;
 const CURRENT_STAGE = getCurrentStage(__filename);
+
 
 const func: DeployFunction = trackFinishedStage(CURRENT_STAGE, async function (hre: HRE) {
   const {
@@ -82,8 +86,9 @@ const func: DeployFunction = trackFinishedStage(CURRENT_STAGE, async function (h
         setToken: await findDependency(TEST_PERP_TOKEN),
         perpV2LeverageModule: await findDependency(PERPV2_LEVERAGE_MODULE),
         perpV2AccountBalance: await findDependency(PERPV2_ACCOUNT_BALANCE),
-        basePriceOracle: await findDependency(ETH_CHAINLINK_ORACLE),
-        quotePriceOracle: await findDependency(USDC_CHAINLINK_ORACLE),
+        baseUSDPriceOracle: await findDependency(ETH_CHAINLINK_ORACLE),
+        twapInterval: ZERO,
+        basePriceDecimalAdjustment: BigNumber.from(ETH_DECIMALS).sub(ETH_USDC_PRICE_FEED_DECIMALS),
         virtualBaseAddress: await findDependency(V_ETH),
         virtualQuoteAddress: await findDependency(V_USD)
       };

--- a/optimism/deployments/constants/001_perpLeverageSystem.ts
+++ b/optimism/deployments/constants/001_perpLeverageSystem.ts
@@ -33,3 +33,6 @@ export const EXCHANGE_SETTINGS = {
   twapMaxTradeSize: ether(10),
   incentivizedTwapMaxTradeSize: ether(20)
 };
+
+export const ETH_DECIMALS = 18;
+export const ETH_USDC_PRICE_FEED_DECIMALS = 8;

--- a/optimism/deployments/utils/types.ts
+++ b/optimism/deployments/utils/types.ts
@@ -7,8 +7,9 @@ export interface PerpV2ContractSettings {
   setToken: Address;
   perpV2LeverageModule: Address;
   perpV2AccountBalance: Address;
-  basePriceOracle: Address;
-  quotePriceOracle: Address;
+  baseUSDPriceOracle: Address;
+  twapInterval: BigNumber;
+  basePriceDecimalAdjustment: BigNumber;
   virtualBaseAddress: Address;
   virtualQuoteAddress: Address;
 }

--- a/optimism/test/deploys/001_perpLeverageSystem.spec.ts
+++ b/optimism/test/deploys/001_perpLeverageSystem.spec.ts
@@ -86,8 +86,7 @@ describe("PerpLeverageSystem", () => {
       expect(strategy.perpV2AccountBalance).to.eq(await findDependency("PERPV2_ACCOUNT_BALANCE"));
       expect(strategy.virtualBaseAddress).to.eq(await findDependency("V_ETH"));
       expect(strategy.virtualQuoteAddress).to.eq(await findDependency("V_USD"));
-      expect(strategy.basePriceOracle).to.eq(await findDependency("ETH_CHAINLINK_ORACLE"));
-      expect(strategy.quotePriceOracle).to.eq(await findDependency("USDC_CHAINLINK_ORACLE"));
+      expect(strategy.baseUSDPriceOracle).to.eq(await findDependency("ETH_CHAINLINK_ORACLE"));
     });
 
     it("should set the correct methodology parameters", async () => {

--- a/optimism/test/deploys/001_perpLeverageSystem.spec.ts
+++ b/optimism/test/deploys/001_perpLeverageSystem.spec.ts
@@ -1,5 +1,6 @@
 import "module-alias/register";
 import { deployments } from "hardhat";
+import { ZERO } from "@utils/constants";
 
 import { Account } from "@utils/types";
 import {
@@ -87,6 +88,8 @@ describe("PerpLeverageSystem", () => {
       expect(strategy.virtualBaseAddress).to.eq(await findDependency("V_ETH"));
       expect(strategy.virtualQuoteAddress).to.eq(await findDependency("V_USD"));
       expect(strategy.baseUSDPriceOracle).to.eq(await findDependency("ETH_CHAINLINK_ORACLE"));
+      expect(strategy.twapInterval).to.eq(ZERO);
+      expect(strategy.basePriceDecimalAdjustment).to.eq(10);
     });
 
     it("should set the correct methodology parameters", async () => {

--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
   "dependencies": {
     "@indexcoop/index-coop-smart-contracts": "^0.2.0",
     "@perp/curie-contract": "^0.14.0-staging",
-    "@setprotocol/set-protocol-v2": "^0.1.9",
-    "@setprotocol/set-v2-strategies": "^0.0.2",
+    "@setprotocol/set-protocol-v2": "^0.1.12",
+    "@setprotocol/set-v2-strategies": "^0.0.4",
     "ethers": "5.5.2",
     "fs-extra": "^5.0.0",
     "module-alias": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,10 +1247,10 @@
     "@sentry/types" "5.29.2"
     tslib "^1.9.3"
 
-"@setprotocol/set-protocol-v2@^0.1.10-fast.0":
-  version "0.1.10-fast.0"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.10-fast.0.tgz#05a76002677c5c4ff76b76f657e94e500b764fd3"
-  integrity sha512-2xjtxBK4yUvAjQkUA3kb3NjShr8FnKhwHZEaUvj7Z59a6EPqfyPqdO9i2+RB/x5K1/vUneiDrKBcWWTR4trMug==
+"@setprotocol/set-protocol-v2@^0.1.11-hardhat.0", "@setprotocol/set-protocol-v2@^0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.12.tgz#4ff67d0d2935148908ddada79bc51fda17c97afa"
+  integrity sha512-0zHRCTgASXR4P8ya0lafF4WSjnVsc6N7QMLiOGymVfuoSJDpDD+jGOn57FnVmgeknmt60frxJYMxxn5XQN9lyw==
   dependencies:
     "@uniswap/v3-sdk" "^3.5.1"
     ethers "^5.5.2"
@@ -1259,24 +1259,12 @@
     module-alias "^2.2.2"
     replace-in-file "^6.1.0"
 
-"@setprotocol/set-protocol-v2@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.9.tgz#1b0eef8667d01405f0b259bc5129986e5db7b53b"
-  integrity sha512-sPbCD6ngw4yIosXyOT+ytFZbFeMyHNOgDA6hdhrXkllsSKoJ2thc9Y6SqzF5kCPkK+bKmVhNF+cMTDMX0lemZg==
+"@setprotocol/set-v2-strategies@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.4.tgz#e71d4a6da3fbb05d64755afe1c1646f0024c78c2"
+  integrity sha512-0TbLst3lBeN9J2fsWJUyTCJq/5TBHZWVVvNZZy6WJtIaAU7eZeXl7RFYuIenERIxrOyKUEdiRbznBlwo9l/6tg==
   dependencies:
-    "@uniswap/v3-sdk" "^3.5.1"
-    ethers "^5.5.2"
-    fs-extra "^5.0.0"
-    jsbi "^3.2.5"
-    module-alias "^2.2.2"
-    replace-in-file "^6.1.0"
-
-"@setprotocol/set-v2-strategies@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.2.tgz#98c4e29a6a60d17c7228569b3a82d66a09a9aed5"
-  integrity sha512-JcR3kt6P3Ej8k/IBarMxlwCJdyFGMGMre3wblJDcAmOWdmQTAwNtKPqBAlSHts6QfmI2IbOluOU7pF/PVDSBTg==
-  dependencies:
-    "@setprotocol/set-protocol-v2" "^0.1.10-fast.0"
+    "@setprotocol/set-protocol-v2" "^0.1.11-hardhat.0"
     "@uniswap/v3-sdk" "^3.5.1"
     ethers "5.5.2"
     fs-extra "^5.0.0"


### PR DESCRIPTION
Also includes updates to the PerpLeverageStrategy deploy script to support changes in [set-v2-strategies PR 12][1]

@0xSachinK Apologies, we have to merge this because the package updates are required to unblock some new Manager deployment script stuff. Could you take a look at commit: [e10e86](https://github.com/SetProtocol/set-v2-strategies-deployments/pull/14/commits/fe10e8626c47f8238793825e1953f78714bd7156) and verify that it has been configured correctly?

Things to check:
+ Should the price feed address be the Chainlink ETH-USDC oracle? This is what I saw in latest perp/curie-deployments npm manifest:
  ```js
  "ETHUSDChainlinkPriceFeed": {
      "address": "0xA36fAF16f31c12285467b1973ee8Fa144ED4d846",
      "createdBlockNumber": 2584337,
      "name": "contracts/ChainlinkPriceFeed.sol:ChainlinkPriceFeed"
    },
  ```

+ Should the decimals adjustment be `18 - 8` ?
+ Should the twapInterval be 0


[1]: https://github.com/SetProtocol/set-v2-strategies/pull/12