### PR TITLE
add delegated manager system polygon staging mainnet deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@indexcoop/index-coop-smart-contracts": "^0.2.0",
     "@perp/curie-contract": "^0.14.0-staging",
     "@setprotocol/set-protocol-v2": "^0.1.14",
-    "@setprotocol/set-v2-strategies": "^0.0.5",
+    "@setprotocol/set-v2-strategies": "^0.0.6",
     "ethers": "5.5.2",
     "fs-extra": "^5.0.0",
     "module-alias": "^2.2.2",

--- a/polygon/deployments/outputs/137-staging.json
+++ b/polygon/deployments/outputs/137-staging.json
@@ -3,10 +3,15 @@
     "network_key": "137-staging",
     "human_friendly_name": "polygon-mainnet-staging",
     "network_id": 137,
-    "last_deployment_stage": 2
+    "last_deployment_stage": 3
   },
   "addresses": {
-    "ExchangeIssuanceZeroEx": "0xF22075FFEB9bCFa7e54d68Cd2f0FbFA17D1bCE35"
+    "ExchangeIssuanceZeroEx": "0xF22075FFEB9bCFa7e54d68Cd2f0FbFA17D1bCE35",
+    "ManagerCore": "0x13C5A1444CC7cF0bCae366ed5BDe13d46dba3311",
+    "DelegatedManagerFactory": "0x6C9A0eAE685a454Edf1f74B027e8910a5A72A6A0",
+    "IssuanceExtension": "0xA16F2F47f26f6d70311A30b35E2332FC417888E1",
+    "StreamingFeeSplitExtension": "0x10ED5F873e8b1a510e5bad029DBbFF235bFef758",
+    "TradeExtension": "0x03641c1E4A7a3daF4cf6aE378153A28B5ca5F787"
   },
   "transactions": {
     "0": {
@@ -20,6 +25,73 @@
         "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
         "0x719E5B865dE407bf38647C1625D193E0CE42111D",
         "0xDef1C0ded9bec7F1a1670819833240f027b25EfF"
+      ],
+      "libraries": {}
+    },
+    "1": {
+      "id": "0xa6e71215fa2d6bc17bfefe6c56c1a27640f7196e6305787fa0e21d129880e912",
+      "name": "ManagerCore",
+      "timestamp": 1647282833272,
+      "verified": true,
+      "description": "Deployed ManagerCore",
+      "contractAddress": "0x13C5A1444CC7cF0bCae366ed5BDe13d46dba3311",
+      "constructorArgs": [],
+      "libraries": {}
+    },
+    "2": {
+      "id": "0xabdcfa7e417cad727f23c51224bcdd0f8c3cb9de48feb8215c081f6e3c99bdbe",
+      "name": "DelegatedManagerFactory",
+      "timestamp": 1647282833629,
+      "verified": true,
+      "description": "Deployed DelegatedManagerFactory",
+      "contractAddress": "0x6C9A0eAE685a454Edf1f74B027e8910a5A72A6A0",
+      "constructorArgs": [
+        "0x13C5A1444CC7cF0bCae366ed5BDe13d46dba3311",
+        "0x2907206B253665EEF4776b8e684D61AFD957B974"
+      ],
+      "libraries": {}
+    },
+    "3": {
+      "id": "0xa342ef8c505395f318c2b1fa1ffcbecfcedfeace58e824078695f021e5247f56",
+      "timestamp": 1647282808078,
+      "description": "Initialized ManagerCore with DelegatedManagerFactory"
+    },
+    "4": {
+      "id": "0xa4002f932412165167389838bb93a693100a842f05c86752fea2f95917df4f8f",
+      "name": "IssuanceExtension",
+      "timestamp": 1647282840886,
+      "verified": true,
+      "description": "Deployed IssuanceExtension",
+      "contractAddress": "0xA16F2F47f26f6d70311A30b35E2332FC417888E1",
+      "constructorArgs": [
+        "0x13C5A1444CC7cF0bCae366ed5BDe13d46dba3311",
+        "0x9e4ACB5737884719B8407F58F0c8cd3F97d2e130"
+      ],
+      "libraries": {}
+    },
+    "5": {
+      "id": "0x68d31740d61ddc0afe12387400ca3817d70e446e208c6429b98f57cdf9c427e1",
+      "name": "StreamingFeeSplitExtension",
+      "timestamp": 1647282847225,
+      "verified": true,
+      "description": "Deployed StreamingFeeSplitExtension",
+      "contractAddress": "0x10ED5F873e8b1a510e5bad029DBbFF235bFef758",
+      "constructorArgs": [
+        "0x13C5A1444CC7cF0bCae366ed5BDe13d46dba3311",
+        "0x2f8FF0546a478DF380f975cA035B95DF82377721"
+      ],
+      "libraries": {}
+    },
+    "6": {
+      "id": "0xcd3b77b2f24568e183c9eabb2a70f7254b9f918233f0295960231ba82a812724",
+      "name": "TradeExtension",
+      "timestamp": 1647282854483,
+      "verified": true,
+      "description": "Deployed TradeExtension",
+      "contractAddress": "0x03641c1E4A7a3daF4cf6aE378153A28B5ca5F787",
+      "constructorArgs": [
+        "0x13C5A1444CC7cF0bCae366ed5BDe13d46dba3311",
+        "0x4F70287526ea9Ba7e799D616ea86635CdAf0de4F"
       ],
       "libraries": {}
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,10 +1271,10 @@
     module-alias "^2.2.2"
     replace-in-file "^6.1.0"
 
-"@setprotocol/set-v2-strategies@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.5.tgz#4f9fc0b9f434ca799d541924b6eb77af361415a0"
-  integrity sha512-UfmOG2Khkn9vitAOQYbSzlE3D5pv5ZKm3daEchCvKrY6gEmn6QhGmhhIlrjL7FrKLPCv6ljNLTJwBmtruQGEUQ==
+"@setprotocol/set-v2-strategies@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.6.tgz#f9a3a39acbddf376c355275dee323a544e3fe2fb"
+  integrity sha512-4Qwgvf05klsrfWC16rzcppL7BCtldlsRZNLXrwZhnx8iUqqb+CGzbE2kEuSJU0vZG0Q0jTEPF6R+GPGIvk0sxA==
   dependencies:
     "@setprotocol/set-protocol-v2" "^0.1.11-hardhat.0"
     "@uniswap/v3-sdk" "^3.5.1"


### PR DESCRIPTION
Deployments
- ManagerCore: [0x13C5A1444CC7cF0bCae366ed5BDe13d46dba3311](https://polygonscan.com/address/0x13c5a1444cc7cf0bcae366ed5bde13d46dba3311)
- DelegatedManagerFactory: [0x6C9A0eAE685a454Edf1f74B027e8910a5A72A6A0](https://polygonscan.com/address/0x6c9a0eae685a454edf1f74b027e8910a5a72a6a0)
- IssuanceExtension: [0xA16F2F47f26f6d70311A30b35E2332FC417888E1](https://polygonscan.com/address/0xa16f2f47f26f6d70311a30b35e2332fc417888e1)
- StreamingFeeSplitExtension: [0x10ED5F873e8b1a510e5bad029DBbFF235bFef758](https://polygonscan.com/address/0x10ed5f873e8b1a510e5bad029dbbff235bfef758)
- TradeExtension: [0x03641c1E4A7a3daF4cf6aE378153A28B5ca5F787](https://polygonscan.com/address/0x03641c1e4a7a3daf4cf6ae378153a28b5ca5f787)

Transactions
- Initialize ManagerCore: [0xa342ef8c505395f318c2b1fa1ffcbecfcedfeace58e824078695f021e5247f56](https://polygonscan.com/tx/0xa342ef8c505395f318c2b1fa1ffcbecfcedfeace58e824078695f021e5247f56)

Notes
- Bump set-v2-strategies package to v0.0.6