### PR TITLE
Verify DelegatedManager contract to automate etherscan verification at set-ui

### DIFF
--- a/ethereum/deploy/003_delegated_manager_contract.ts
+++ b/ethereum/deploy/003_delegated_manager_contract.ts
@@ -1,0 +1,59 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment as HRE } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  prepareDeployment,
+  getContractAddress,
+  getCurrentStage,
+  saveContractDeployment,
+  stageAlreadyFinished,
+  trackFinishedStage
+} from "@utils/index";
+
+import { getRandomAddress } from "@utils/accountUtils";
+import { CONTRACT_NAMES } from "../deployments/constants/003_delegated_manager_contract";
+
+const CURRENT_STAGE = getCurrentStage(__filename);
+
+// The DelegatedManager contract is factory deployed (usually in tandem with a SetToken).
+// This script deploys (and verifies) a non-functional manager to the chain to enabled automated
+// Etherscan verification for any additional instances created by the DelegatedManagerFactory
+const func: DeployFunction = trackFinishedStage(CURRENT_STAGE, async function (hre: HRE) {
+  const { deploy, deployer } = await prepareDeployment(hre);
+
+  const contractName = CONTRACT_NAMES.DELEGATED_MANAGER;
+
+  const constructorArgs = [
+    await getRandomAddress(), // _setToken
+    await getRandomAddress(), // _factory
+    await getRandomAddress(), // _methodologist
+    [],                       // _extensions
+    [],                       // _operators
+    [],                       // _allowedAssets
+    false                     // _useAssetAllowlist
+  ];
+
+  if (await getContractAddress(contractName) === "") {
+
+    const delegatedManagerDeploy = await deploy(contractName, {
+      from: deployer,
+      args: constructorArgs,
+      log: true,
+    });
+
+    delegatedManagerDeploy.receipt &&
+      (await saveContractDeployment({
+        name: contractName,
+        contractAddress: delegatedManagerDeploy.address,
+        id: delegatedManagerDeploy.receipt!.transactionHash,
+        description: `Deployed ${contractName}`,
+        constructorArgs,
+      }));
+  }
+});
+
+func.skip = stageAlreadyFinished(CURRENT_STAGE);
+
+export default func;

--- a/ethereum/deployments/constants/003_delegated_manager_contract.ts
+++ b/ethereum/deployments/constants/003_delegated_manager_contract.ts
@@ -1,0 +1,3 @@
+export const CONTRACT_NAMES = {
+  DELEGATED_MANAGER: "DelegatedManager"
+};

--- a/ethereum/deployments/outputs/1-staging.json
+++ b/ethereum/deployments/outputs/1-staging.json
@@ -3,7 +3,7 @@
     "network_key": "1-staging",
     "human_friendly_name": "main-net-staging",
     "network_id": 1,
-    "last_deployment_stage": 3
+    "last_deployment_stage": 4
   },
   "addresses": {
     "ExchangeIssuanceZeroEx": "0x939eD0665f6CC78882C0ef451d2636110FEA87fe",
@@ -11,7 +11,8 @@
     "DelegatedManagerFactory": "0x55cC794247Ec45db9A1D5B0F26055B7B729F19D2",
     "IssuanceExtension": "0xFc4E27bDb739A6e2AAdA6c8764860bec6F4288Ee",
     "StreamingFeeSplitExtension": "0x946735c0B0C47dd74a38eAe96E75E0eFF5BFB93E",
-    "TradeExtension": "0xEa2F360529dFB5A3423ec84D44482673C28960e5"
+    "TradeExtension": "0xEa2F360529dFB5A3423ec84D44482673C28960e5",
+    "DelegatedManager": "0x6fC29CD2C19c5b29C2bD4dd2EFcFFB5Ec9691855"
   },
   "transactions": {
     "0": {
@@ -95,6 +96,24 @@
       "id": "0xf1dc847c5ca60e8dbc170ca8672ffb5d30cbd4d42c37a573c7cae9a1e3fe1fcb",
       "timestamp": 1648694500282,
       "description": "Initialized ManagerCore with DelegatedManagerFactory, IssuanceExtension, StreamingFeeSplitExtension, and TradeExtension"
+    },
+    "7": {
+      "id": "0x29a72e6ee710eb356d074294bbefe794fb1434a16f4f4bbea94b9e85625d6d98",
+      "name": "DelegatedManager",
+      "timestamp": 1648855357544,
+      "verified": true,
+      "description": "Deployed DelegatedManager",
+      "contractAddress": "0x6fC29CD2C19c5b29C2bD4dd2EFcFFB5Ec9691855",
+      "constructorArgs": [
+        "0x02f04dD09a9074ba25C5fddDA8998ddF8994f1F0",
+        "0x2899384007FC7eFF519745140e8c05bc5FF5f0C5",
+        "0xaE5Ef86DaCaa88668c640cD59e99580ECbA35f3b",
+        [],
+        [],
+        [],
+        false
+      ],
+      "libraries": {}
     }
   }
 }

--- a/optimism/deploy/004_delegated_manager_contract.ts
+++ b/optimism/deploy/004_delegated_manager_contract.ts
@@ -1,0 +1,59 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment as HRE } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  prepareDeployment,
+  getContractAddress,
+  getCurrentStage,
+  saveContractDeployment,
+  stageAlreadyFinished,
+  trackFinishedStage
+} from "@utils/index";
+
+import { getRandomAddress } from "@utils/accountUtils";
+import { CONTRACT_NAMES } from "../deployments/constants/004_delegated_manager_contract";
+
+const CURRENT_STAGE = getCurrentStage(__filename);
+
+// The DelegatedManager contract is factory deployed (usually in tandem with a SetToken).
+// This script deploys (and verifies) a non-functional manager to the chain to enabled automated
+// Etherscan verification for any additional instances created by the DelegatedManagerFactory
+const func: DeployFunction = trackFinishedStage(CURRENT_STAGE, async function (hre: HRE) {
+  const { deploy, deployer } = await prepareDeployment(hre);
+
+  const contractName = CONTRACT_NAMES.DELEGATED_MANAGER;
+
+  const constructorArgs = [
+    await getRandomAddress(), // _setToken
+    await getRandomAddress(), // _factory
+    await getRandomAddress(), // _methodologist
+    [],                       // _extensions
+    [],                       // _operators
+    [],                       // _allowedAssets
+    false                     // _useAssetAllowlist
+  ];
+
+  if (await getContractAddress(contractName) === "") {
+
+    const delegatedManagerDeploy = await deploy(contractName, {
+      from: deployer,
+      args: constructorArgs,
+      log: true,
+    });
+
+    delegatedManagerDeploy.receipt &&
+      (await saveContractDeployment({
+        name: contractName,
+        contractAddress: delegatedManagerDeploy.address,
+        id: delegatedManagerDeploy.receipt!.transactionHash,
+        description: `Deployed ${contractName}`,
+        constructorArgs,
+      }));
+  }
+});
+
+func.skip = stageAlreadyFinished(CURRENT_STAGE);
+
+export default func;

--- a/optimism/deployments/constants/004_delegated_manager_contract.ts
+++ b/optimism/deployments/constants/004_delegated_manager_contract.ts
@@ -1,0 +1,3 @@
+export const CONTRACT_NAMES = {
+  DELEGATED_MANAGER: "DelegatedManager"
+};

--- a/optimism/deployments/outputs/10-staging.json
+++ b/optimism/deployments/outputs/10-staging.json
@@ -3,7 +3,7 @@
     "network_key": "10-staging",
     "human_friendly_name": "optimism-mainnet-staging",
     "network_id": 10,
-    "last_deployment_stage": 4
+    "last_deployment_stage": 5
   },
   "addresses": {
     "ExchangeIssuanceZeroEx - DEPRECATED": "0xb56DEb6aBC9AB381ACa33ddb7BAa9fCb4C2Db8f5",
@@ -12,7 +12,8 @@
     "DelegatedManagerFactory": "0x4E86bd25eac00812243295d7Ad7Cb59cee3f79D8",
     "IssuanceExtension": "0xD59D7CcCdcAacb4c283bA6FeC950eDf7D087dAd5",
     "StreamingFeeSplitExtension": "0xFfA0B13283B76e1278Fa5072b2da04cb9534b937",
-    "TradeExtension": "0x9a7671DB5d28DD85f05D67ac18ba38F4B3862904"
+    "TradeExtension": "0x9a7671DB5d28DD85f05D67ac18ba38F4B3862904",
+    "DelegatedManager": "0xf640aec9141c14D3FEF5F0514712d23e1436E033"
   },
   "transactions": {
     "0": {
@@ -110,6 +111,24 @@
       "id": "0xf395144faa0ae7c246f70d693e1ff7efba17bac100b2902cf9a4f1b873f0d19d",
       "timestamp": 1648699065266,
       "description": "Initialized ManagerCore with DelegatedManagerFactory, IssuanceExtension, StreamingFeeSplitExtension, and TradeExtension"
+    },
+    "8": {
+      "id": "0x551a34b422115625804e43e9c9d016b196626e1e23589b11a92abe00ee694445",
+      "name": "DelegatedManager",
+      "timestamp": 1648853761399,
+      "verified": true,
+      "description": "Deployed DelegatedManager",
+      "contractAddress": "0xf640aec9141c14D3FEF5F0514712d23e1436E033",
+      "constructorArgs": [
+        "0x1F8F0F14584841B581351c3a34ED2bd8E7cb3483",
+        "0x8B05c85A3c5C7aE1C129aD0a6E62Cb8cCAc1d94F",
+        "0xAa460a7582A26429D011df4857251C6BC1A461Ef",
+        [],
+        [],
+        [],
+        false
+      ],
+      "libraries": {}
     }
   }
 }

--- a/polygon/deploy/003_delegated_manager_contract.ts
+++ b/polygon/deploy/003_delegated_manager_contract.ts
@@ -1,0 +1,59 @@
+import "module-alias/register";
+
+import { HardhatRuntimeEnvironment as HRE } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import {
+  prepareDeployment,
+  getContractAddress,
+  getCurrentStage,
+  saveContractDeployment,
+  stageAlreadyFinished,
+  trackFinishedStage
+} from "@utils/index";
+
+import { getRandomAddress } from "@utils/accountUtils";
+import { CONTRACT_NAMES } from "../deployments/constants/003_delegated_manager_contract";
+
+const CURRENT_STAGE = getCurrentStage(__filename);
+
+// The DelegatedManager contract is factory deployed (usually in tandem with a SetToken).
+// This script deploys (and verifies) a non-functional manager to the chain to enabled automated
+// Etherscan verification for any additional instances created by the DelegatedManagerFactory
+const func: DeployFunction = trackFinishedStage(CURRENT_STAGE, async function (hre: HRE) {
+  const { deploy, deployer } = await prepareDeployment(hre);
+
+  const contractName = CONTRACT_NAMES.DELEGATED_MANAGER;
+
+  const constructorArgs = [
+    await getRandomAddress(), // _setToken
+    await getRandomAddress(), // _factory
+    await getRandomAddress(), // _methodologist
+    [],                       // _extensions
+    [],                       // _operators
+    [],                       // _allowedAssets
+    false                     // _useAssetAllowlist
+  ];
+
+  if (await getContractAddress(contractName) === "") {
+
+    const delegatedManagerDeploy = await deploy(contractName, {
+      from: deployer,
+      args: constructorArgs,
+      log: true,
+    });
+
+    delegatedManagerDeploy.receipt &&
+      (await saveContractDeployment({
+        name: contractName,
+        contractAddress: delegatedManagerDeploy.address,
+        id: delegatedManagerDeploy.receipt!.transactionHash,
+        description: `Deployed ${contractName}`,
+        constructorArgs,
+      }));
+  }
+});
+
+func.skip = stageAlreadyFinished(CURRENT_STAGE);
+
+export default func;

--- a/polygon/deployments/constants/003_delegated_manager_contract.ts
+++ b/polygon/deployments/constants/003_delegated_manager_contract.ts
@@ -1,0 +1,3 @@
+export const CONTRACT_NAMES = {
+  DELEGATED_MANAGER: "DelegatedManager"
+};

--- a/polygon/deployments/outputs/137-staging.json
+++ b/polygon/deployments/outputs/137-staging.json
@@ -3,7 +3,7 @@
     "network_key": "137-staging",
     "human_friendly_name": "polygon-mainnet-staging",
     "network_id": 137,
-    "last_deployment_stage": 3
+    "last_deployment_stage": 4
   },
   "addresses": {
     "ExchangeIssuanceZeroEx": "0xF22075FFEB9bCFa7e54d68Cd2f0FbFA17D1bCE35",
@@ -16,7 +16,8 @@
     "DelegatedManagerFactory": "0xa5351d5F6fE586A7A2eE0A5B7f797F5Fb686082B",
     "IssuanceExtension": "0x802569a5AC139650956f79bB0129C767cC491DE4",
     "StreamingFeeSplitExtension": "0x171Bf119b7Da5E24Ea1f41c81e0DAD41E57FeE48",
-    "TradeExtension": "0x34548881b83dC247Ca11ed4cfbe2cbeB5a2Bf0D1"
+    "TradeExtension": "0x34548881b83dC247Ca11ed4cfbe2cbeB5a2Bf0D1",
+    "DelegatedManager": "0x1f786c6535c2b445879919BfE9105A3DBaf56400"
   },
   "transactions": {
     "0": {
@@ -100,6 +101,24 @@
       "id": "0x793fc731ab030e1c4a333061fe13cc29ba907bc37ee65efb41c319de3243eb43",
       "timestamp": 1648492713859,
       "description": "Initialized ManagerCore with DelegatedManagerFactory, IssuanceExtension, StreamingFeeSplitExtension, and TradeExtension"
+    },
+    "7": {
+      "id": "0x93b787e754b712bd78293b91cbccb73288238c1fc1a4772e0605f6af30a75030",
+      "name": "DelegatedManager",
+      "timestamp": 1647477439179,
+      "verified": true,
+      "description": "Deployed DelegatedManager",
+      "contractAddress": "0x1f786c6535c2b445879919BfE9105A3DBaf56400",
+      "constructorArgs": [
+        "0x1A22553224CDD2849E00193433888C6f74604396",
+        "0x304cb210BAa594F62da4A6799af8F4Ba8E751fe9",
+        "0x47aCfaB211c58b561d3286c0715C57f25d8f9c98",
+        [],
+        [],
+        [],
+        false
+      ],
+      "libraries": {}
     }
   }
 }

--- a/polygon/deployments/outputs/137-staging.json
+++ b/polygon/deployments/outputs/137-staging.json
@@ -17,7 +17,8 @@
     "IssuanceExtension": "0x802569a5AC139650956f79bB0129C767cC491DE4",
     "StreamingFeeSplitExtension": "0x171Bf119b7Da5E24Ea1f41c81e0DAD41E57FeE48",
     "TradeExtension": "0x34548881b83dC247Ca11ed4cfbe2cbeB5a2Bf0D1",
-    "DelegatedManager": "0x1f786c6535c2b445879919BfE9105A3DBaf56400"
+    "DelegatedManager--DEPRECATED": "0x1f786c6535c2b445879919BfE9105A3DBaf56400",
+    "DelegatedManager": "0x53d026AE6897Dd0eF2A3d6Dbe56d6eb2326426ce"
   },
   "transactions": {
     "0": {
@@ -113,6 +114,24 @@
         "0x1A22553224CDD2849E00193433888C6f74604396",
         "0x304cb210BAa594F62da4A6799af8F4Ba8E751fe9",
         "0x47aCfaB211c58b561d3286c0715C57f25d8f9c98",
+        [],
+        [],
+        [],
+        false
+      ],
+      "libraries": {}
+    },
+    "8": {
+      "id": "0xda03a2b7a24368afa85d1849f7f6c8e13ac48f23effb50f6586b7e53a846b7f3",
+      "name": "DelegatedManager",
+      "timestamp": 1648497299142,
+      "verified": true,
+      "description": "Deployed DelegatedManager",
+      "contractAddress": "0x53d026AE6897Dd0eF2A3d6Dbe56d6eb2326426ce",
+      "constructorArgs": [
+        "0xf11DD51CcDc48C4A6cB8391eD0bfdec80d61eAF1",
+        "0x59882275DEf31A556288023d9c3409EEcc560Ad4",
+        "0xb5898a1399B510adFA467330cc8dc297154f3b98",
         [],
         [],
         [],

--- a/polygon/deployments/outputs/137-staging.json
+++ b/polygon/deployments/outputs/137-staging.json
@@ -17,8 +17,8 @@
     "IssuanceExtension": "0x802569a5AC139650956f79bB0129C767cC491DE4",
     "StreamingFeeSplitExtension": "0x171Bf119b7Da5E24Ea1f41c81e0DAD41E57FeE48",
     "TradeExtension": "0x34548881b83dC247Ca11ed4cfbe2cbeB5a2Bf0D1",
-    "DelegatedManager--DEPRECATED": "0x1f786c6535c2b445879919BfE9105A3DBaf56400",
-    "DelegatedManager": "0x53d026AE6897Dd0eF2A3d6Dbe56d6eb2326426ce"
+    "DelegatedManager--DEPRECATED": "0x53d026AE6897Dd0eF2A3d6Dbe56d6eb2326426ce",
+    "DelegatedManager": "0x4B34bb7e210F5a462E8cD2d92555D1BD18d03bf2"
   },
   "transactions": {
     "0": {
@@ -132,6 +132,24 @@
         "0xf11DD51CcDc48C4A6cB8391eD0bfdec80d61eAF1",
         "0x59882275DEf31A556288023d9c3409EEcc560Ad4",
         "0xb5898a1399B510adFA467330cc8dc297154f3b98",
+        [],
+        [],
+        [],
+        false
+      ],
+      "libraries": {}
+    },
+    "9": {
+      "id": "0xcd5b2e6a8d22c7e9472a300011a6cf42a065a76aa76fcf4f9ed1d173f19f527b",
+      "name": "DelegatedManager",
+      "timestamp": 1648595445837,
+      "verified": true,
+      "description": "Deployed DelegatedManager",
+      "contractAddress": "0x4B34bb7e210F5a462E8cD2d92555D1BD18d03bf2",
+      "constructorArgs": [
+        "0x3e95d93bb778649AC8167e9C59965F140198F6E5",
+        "0x02C2a189727479c187de45d4040DA078D3F84FF8",
+        "0x1487970505128cA61f8A401e1745C6fE0006B02A",
         [],
         [],
         [],


### PR DESCRIPTION
This contract is fake so I've omitted tests. We just want a single successful verification on the 3 networks that will support the DelegatedManagerSystem. 

**TODO**
- [x] Finalize contracts before deploying to all networks. (Bytecodes need to match)

**Polygon**
+ [0x1f786c6535c2b445879919BfE9105A3DBaf56400][1] (not auto-verifying, etherscan investigating)

**Optimism**
+ [0xf640aec9141c14D3FEF5F0514712d23e1436E033][3] (not auto-verifying, etherscan investigating)

**Ethereum**
+ [0x6fC29CD2C19c5b29C2bD4dd2EFcFFB5Ec9691855][2]

[1]: https://polygonscan.com/address/0x1f786c6535c2b445879919BfE9105A3DBaf56400#code
[2]: https://etherscan.io/address/0x6fC29CD2C19c5b29C2bD4dd2EFcFFB5Ec9691855#code
[3]: https://optimistic.etherscan.io/address/0xf640aec9141c14D3FEF5F0514712d23e1436E033#code